### PR TITLE
Update fastmail server addresses

### DIFF
--- a/docs/tutorials/fastmail.rst
+++ b/docs/tutorials/fastmail.rst
@@ -10,13 +10,13 @@ the settings to use::
 
     [storage cal]
     type = "caldav"
-    url = "https://caldav.messagingengine.com/"
+    url = "https://caldav.fastmail.com/"
     username = "..."
     password = "..."
 
     [storage card]
     type = "carddav"
-    url = "https://carddav.messagingengine.com/"
+    url = "https://carddav.fastmail.com/"
     username = "..."
     password = "..."
 


### PR DESCRIPTION
The fastmail server addresses have changed and these above ones should be used now.